### PR TITLE
add dependency to zmq lib

### DIFF
--- a/install.py
+++ b/install.py
@@ -318,7 +318,8 @@ def install_dependencies():
         'simplejson >= 1.9.2',
         'WTForms >= 2.0',
         'WTForms-Components',
-        'pillow'
+        'pillow',
+        'pyzmq'
     ])
 
 #    pkg_resources.get_distribution('django').activate()


### PR DESCRIPTION
I needed to add this dep in order to resolve the following error :

```
Traceback (most recent call last):
  File "/domoweb/Domoweb.py", line 10, in <module>
    from zmq.eventloop import ioloop
ImportError: No module named zmq.eventloop
```
