### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,4 +30,4 @@
 	url = https://github.com/naoxink/notifIt.git
 [submodule "components/core-shared-lib"]
 	path = components/core-shared-lib
-	url = git@github.com:Polymer/core-shared-lib.git
+	url = https://github.com/Polymer/core-shared-lib.git


### PR DESCRIPTION
not everyone has a github account and using ssh protocol prevent some folks to init submodules :

Cloning into '/domoweb'...
Submodule 'components/core-shared-lib' (git@github.com:Polymer/core-shared-lib.git) registered for path 'components/core-shared-lib'
Submodule 'components/platform' (https://github.com/Polymer/platform.git) registered for path 'components/platform'
Submodule 'components/polymer' (https://github.com/Polymer/polymer.git) registered for path 'components/polymer'
Submodule 'static/libraries/d3' (https://github.com/mbostock/d3.git) registered for path 'static/libraries/d3'
Submodule 'static/libraries/draggability' (https://github.com/desandro/draggabilly.git) registered for path 'static/libraries/draggability'
Submodule 'static/libraries/file-uploader' (https://github.com/Valums-File-Uploader/file-uploader.git) registered for path 'static/libraries/file-uploader'
Submodule 'static/libraries/i18next' (https://github.com/jamuhl/i18next.git) registered for path 'static/libraries/i18next'
Submodule 'static/libraries/image-picker' (https://github.com/rvera/image-picker.git) registered for path 'static/libraries/image-picker'
Submodule 'static/libraries/moment' (https://github.com/moment/moment.git) registered for path 'static/libraries/moment'
Submodule 'static/libraries/notifit' (https://github.com/naoxink/notifIt.git) registered for path 'static/libraries/notifit'
Submodule 'static/libraries/packery' (https://github.com/metafizzy/packery.git) registered for path 'static/libraries/packery'
Cloning into 'components/core-shared-lib'...
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Clone of 'git@github.com:Polymer/core-shared-lib.git' into submodule path 'components/core-shared-lib' failed
