### PR TITLE
Fix widget commandRollingShutter at good direction, according to DT_type

### DIFF
--- a/packs/widgets/basic/commandRollingShutter.html
+++ b/packs/widgets/basic/commandRollingShutter.html
@@ -67,14 +67,14 @@
             },
             open: function(e) {
                 var parameters = {};
-                parameters[this.$.primary.parameters[0]['key']] = 1;
+                parameters[this.$.primary.parameters[0]['key']] = 0;
                 this.$.primary.send(parameters);
                 e.preventDefault();
                 e.stopPropagation();
             },
             close: function(e) {
                 var parameters = {};
-                parameters[this.$.primary.parameters[0]['key']] = 0;
+                parameters[this.$.primary.parameters[0]['key']] = 1;
                 this.$.primary.send(parameters);
                 e.preventDefault();
                 e.stopPropagation();


### PR DESCRIPTION
Good commands 0/1 for these bool types :
    "DT_Step": {
        "labels": {
            "0": "Decrease",
            "1": "Increase"
        },
        "parent": "DT_Bool",
        "childs": []
    },
    "DT_UpDown": {
        "labels": {
            "0": "Up",
            "1": "Down"
        },
        "parent": "DT_Bool",
        "childs": []
    },
    "DT_OpenClose": {
        "labels": {
            "0": "Open",
            "1": "Close"
        },
