### PR TITLE
Update sensorChartMulti.html idon for dt_type used by wind speed

### DIFF
--- a/packs/widgets/basic/sensorChartMulti.html
+++ b/packs/widgets/basic/sensorChartMulti.html
@@ -299,6 +299,8 @@
                 break;
                 case 'DT_Humidity': var icon = '<i class="wi wi-humidity"></i>';
                 break;
+                case 'DT_kmhSpeed': var icon = '<i class="wi wi-cloud-refresh"></i>';
+                break;
                 default: var icon = '<i class="wi wi-na"></i>';
                 break;
             }


### PR DESCRIPTION
Accord with domodroid icon but not sure it is good idea as this datatype could be used with other plugin and not refered to wind speed :(
In domodroid we test the sensor name "Wind speed" directly.